### PR TITLE
correct D syntax

### DIFF
--- a/lang/ඞ.d
+++ b/lang/ඞ.d
@@ -1,5 +1,6 @@
-import std;
+import std.stdio;
+
 void main()
 {
-    writeln("ඞ amogus");
+    write("ඞ amogus");
 }


### PR DESCRIPTION
In the ඞ.d file, `writeln("ඞ amogus");` is used to output 'ඞ amogus' however it would be better to use the `write()` function instead. The reason for this is `writeln()` creates a newline after the string. This is the equivalent of e. g. `print("ඞ amogus\n")`
in python. So if we're strictly outputting `ඞ amogus`, a newline isn't needed.

I also changed the import statement to `import std.stdio;` because we aren't using the full `std` library.

It might be worth noting as well that the `dmd` compiler for dlang can't actually compile this as the unicode character in the filename confuses it. changing the filename to anything else will work but it still doesn't print the unicode character right.
[This is just with the DMD compiler though, I haven't tried GDC or LDC.](https://wiki.dlang.org/Compilers)